### PR TITLE
Temporarily fix build (Mirai-Purpur 1.18.2)

### DIFF
--- a/patches/server/0001-Mirai-Branding-Changes.patch
+++ b/patches/server/0001-Mirai-Branding-Changes.patch
@@ -231,7 +231,7 @@ index 74630b99102bbb082ce48b8e76be29fc944cf9d8..66c9eafb91a95c5987b206a70824a3ff
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
-index 99597258e8e88cd9e2c901c4ac3ff7faeeabee2b..dde8458ce2d8cc9aceaa4c62acdaf2ff0c0d610a 100644
+index 99597258e8e88cd9e2c901c4ac3ff7faeeabee2b..e35c6c83d22ce166c59c0e1312da3a59285e1c2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 @@ -1,29 +1,9 @@
@@ -262,6 +262,6 @@ index 99597258e8e88cd9e2c901c4ac3ff7faeeabee2b..dde8458ce2d8cc9aceaa4c62acdaf2ff
 -        }
 -
 -        return result;
-+        return "1.18.2-R0.1-SNAPSHOT (Purpur build)"; // Mirai - hardcode version, it's obviously 1.18.2
++        return "1.18.2-R0.1-SNAPSHOT"; // Mirai - hardcode version, it's obviously 1.18.2
      }
  }

--- a/patches/server/0085-Change-SimpleYAML-Version.patch
+++ b/patches/server/0085-Change-SimpleYAML-Version.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pascalpex <pascalpex@gmail.com>
+Date: Tue, 22 Mar 2022 12:02:53 +0100
+Subject: [PATCH] Change SimpleYAML Version
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 613e83a445d645229f3c8401aad7fc7ff781f50f..0aab98fb1ad05b1800f2facf904e2288da5c4501 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -59,7 +59,7 @@ dependencies {
+ 
+     // Pufferfish start
+     implementation("org.yaml:snakeyaml:1.28")
+-    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:ed30ff3e6b") {
++    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:1.8") {
+         exclude(group="org.yaml", module="snakeyaml")
+     }
+     // Pufferfish end


### PR DESCRIPTION
This fixes the build issue on github actions on the purpur 1.18.2 branch by changing the version of [Simple-YAML](https://github.com/Carleslc/Simple-YAML) used by Mirai.
This is probably only needed until Purpur updates their Pufferfish upstream.