### PR TITLE
Temporarily fix build (Mirai-Purpur 1.18.2)

### DIFF
--- a/patches/server/0085-Change-SimpleYAML-Version.patch
+++ b/patches/server/0085-Change-SimpleYAML-Version.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pascalpex <pascalpex@gmail.com>
+Date: Tue, 22 Mar 2022 12:02:53 +0100
+Subject: [PATCH] Change SimpleYAML Version
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index 613e83a445d645229f3c8401aad7fc7ff781f50f..0aab98fb1ad05b1800f2facf904e2288da5c4501 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -59,7 +59,7 @@ dependencies {
+ 
+     // Pufferfish start
+     implementation("org.yaml:snakeyaml:1.28")
+-    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:ed30ff3e6b") {
++    implementation ("me.carleslc.Simple-YAML:Simple-Yaml:1.8") {
+         exclude(group="org.yaml", module="snakeyaml")
+     }
+     // Pufferfish end


### PR DESCRIPTION
This fixes the build issue on github actions on the purpur 1.18.2 branch by changing the version of [Simple-YAML](https://github.com/Carleslc/Simple-YAML) used by Mirai.
This is probably only needed until Purpur updates their Pufferfish upstream.